### PR TITLE
Using HTTPS url instead of HTTP.

### DIFF
--- a/tasty_paginated_scraper.rb
+++ b/tasty_paginated_scraper.rb
@@ -10,7 +10,7 @@ ranges.each do |range|
   page_data = []
 
   range.each do |page|
-    delicious_url = "http://del.icio.us/#{username}?&page=#{page}"
+    delicious_url = "https://del.icio.us/#{username}?&page=#{page}"
     doc = Nokogiri::HTML(open(delicious_url))
 
     date_selector = '.articleThumbBlockOuter'

--- a/tasty_scraper.rb
+++ b/tasty_scraper.rb
@@ -6,7 +6,7 @@ number_of_pages = ARGV[1].to_i
 page_data = []
 
 (1..number_of_pages).to_a.each do |page|
-  delicious_url = "http://del.icio.us/#{username}?&page=#{number}"
+  delicious_url = "https://del.icio.us/#{username}?&page=#{number}"
   doc = Nokogiri::HTML(open(delicious_url))
 
   date_selector = '.articleThumbBlockOuter'


### PR DESCRIPTION
Delicious now automatically redirects to HTTPS.
This leads to an error in `open-uri.rb`:
```
/usr/lib/ruby/2.3.0/open-uri.rb:225:in `open_loop': redirection forbidden:
http://del.icio.us/pyrho?&page=1 -> https://del.icio.us/pyrho?&page=1 (RuntimeError)
```

Using directly the HTTPS URL fixes this issue.